### PR TITLE
Fulfilled user stories 5 to 18 (apart from 8 & 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,51 @@ I can see two clickable elements with corresponding IDs: id="break-decrement" an
 > User Story # 4
 
 I can see two clickable elements with corresponding IDs: id="break-increment" and id="session-increment".
+
+> User Story # 5
+
+I can see an element with a corresponding id="break-length", which by default (on load) displays a value of 5.
+
+> User Story # 6
+
+I can see an element with a corresponding id="session-length", which by default displays a value of 25.
+
+> User Story # 7
+
+I can see an element with a corresponding id="timer-label", that contains a string indicating a session is initialized (e.g. "Session").
+
+> #8
+
+> User Story # 9
+
+I can see a clickable element with a corresponding id="start_stop".
+
+> User Story # 10
+
+I can see a clickable element with a corresponding id="reset".
+
+> #11
+
+> User Story # 12
+
+When I click the element with the id of break-decrement, the value within id="break-length" decrements by a value of 1, and I can see the updated value.
+
+> User Story # 13
+
+When I click the element with the id of break-increment, the value within id="break-length" increments by a value of 1, and I can see the updated value.
+
+> User Story # 14
+
+When I click the element with the id of session-decrement, the value within id="session-length" decrements by a value of 1, and I can see the updated value.
+
+> User Story # 15
+
+When I click the element with the id of session-increment, the value within id="session-length" increments by a value of 1, and I can see the updated value.
+
+> User Story # 16
+
+I should not be able to set a session or break length to <= 0.
+
+> User Story # 17
+
+I should not be able to set a session or break length to > 60.

--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ I should not be able to set a session or break length to <= 0.
 > User Story # 17
 
 I should not be able to set a session or break length to > 60.
+
+> User Story # 18
+
+When I first click the element with id="start_stop", the timer should begin running from the value currently displayed in id="session-length", even if the value has been incremented or decremented from the original value of 25.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "moment": "^2.29.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-fcctest": "^2.0.3",

--- a/src/pomodoro/ControlElement.js
+++ b/src/pomodoro/ControlElement.js
@@ -15,7 +15,9 @@ function ControlElement(props) {
           onClick={props.increaseTime}>
           <i class="bi bi-arrow-bar-up"></i>
         </span>
-        <span className="ctrl-display">{props.time}</span>
+        <span className="ctrl-display" id={props.length}>
+          {props.time}
+        </span>
         <span
           className="ctrl"
           id={props.decrement}

--- a/src/pomodoro/ControlElement.js
+++ b/src/pomodoro/ControlElement.js
@@ -9,11 +9,17 @@ function ControlElement(props) {
         (MINs)
       </p>
       <div className="controls">
-        <span className="ctrl" id={props.increment}>
+        <span
+          className="ctrl"
+          id={props.increment}
+          onClick={props.increaseTime}>
           <i class="bi bi-arrow-bar-up"></i>
         </span>
         <span className="ctrl-display">{props.time}</span>
-        <span className="ctrl" id={props.decrement}>
+        <span
+          className="ctrl"
+          id={props.decrement}
+          onClick={props.decreaseTime}>
           <i class="bi bi-arrow-bar-down"></i>
         </span>
       </div>

--- a/src/pomodoro/ControlElement.js
+++ b/src/pomodoro/ControlElement.js
@@ -3,7 +3,7 @@ import React from 'react';
 function ControlElement(props) {
   return (
     <div className="control-element">
-      <p class="ctrl-label" id={props.identity}>
+      <p className="ctrl-label" id={props.identity}>
         {props.title}
         <br />
         (MINs)
@@ -13,7 +13,7 @@ function ControlElement(props) {
           className="ctrl"
           id={props.increment}
           onClick={props.increaseTime}>
-          <i class="bi bi-arrow-bar-up"></i>
+          <i className="bi bi-arrow-bar-up"></i>
         </span>
         <span className="ctrl-display" id={props.length}>
           {props.time}
@@ -22,7 +22,7 @@ function ControlElement(props) {
           className="ctrl"
           id={props.decrement}
           onClick={props.decreaseTime}>
-          <i class="bi bi-arrow-bar-down"></i>
+          <i className="bi bi-arrow-bar-down"></i>
         </span>
       </div>
     </div>

--- a/src/pomodoro/DisplayPanel.js
+++ b/src/pomodoro/DisplayPanel.js
@@ -13,11 +13,11 @@ function DisplayPanel(props) {
       </div>
       <div className="timer-controls">
         <span className="ctrl-alt" id="start_stop">
-          <i class="bi bi-play"></i>
-          <i class="bi bi-pause"></i>
+          <i className="bi bi-play"></i>
+          <i className="bi bi-pause"></i>
         </span>
         <span className="ctrl" onClick={props.reset} id="reset">
-          <i class="bi bi-arrow-repeat"></i>
+          <i className="bi bi-arrow-repeat"></i>
         </span>
       </div>
     </div>

--- a/src/pomodoro/DisplayPanel.js
+++ b/src/pomodoro/DisplayPanel.js
@@ -4,15 +4,19 @@ function DisplayPanel(props) {
   return (
     <div id="display_panel">
       <div>
-        <span className="display-label">{props.title}</span>
-        <span className="timer-display">{props.time}</span>
+        <span className="display-label" id="timer-label">
+          {props.title}
+        </span>
+        <span className="timer-display" id="time-left">
+          {props.time}
+        </span>
       </div>
       <div className="timer-controls">
-        <span className="ctrl-alt">
+        <span className="ctrl-alt" id="start_stop">
           <i class="bi bi-play"></i>
           <i class="bi bi-pause"></i>
         </span>
-        <span className="ctrl">
+        <span className="ctrl" onClick={props.reset} id="reset">
           <i class="bi bi-arrow-repeat"></i>
         </span>
       </div>

--- a/src/pomodoro/DisplayPanel.js
+++ b/src/pomodoro/DisplayPanel.js
@@ -12,7 +12,7 @@ function DisplayPanel(props) {
         </span>
       </div>
       <div className="timer-controls">
-        <span className="ctrl-alt" id="start_stop">
+        <span className="ctrl-alt" onClick={props.timerControl} id="start_stop">
           <i className="bi bi-play"></i>
           <i className="bi bi-pause"></i>
         </span>

--- a/src/pomodoro/index.js
+++ b/src/pomodoro/index.js
@@ -14,6 +14,7 @@ class Pomodoro extends React.Component {
     this.breakTimeDecrease = this.breakTimeDecrease.bind(this);
     this.sessionTimeIncrease = this.sessionTimeIncrease.bind(this);
     this.sessionTimeDecrease = this.sessionTimeDecrease.bind(this);
+    this.handleReset = this.handleReset.bind(this);
   }
 
   breakTimeIncrease() {
@@ -48,6 +49,13 @@ class Pomodoro extends React.Component {
     });
   }
 
+  handleReset() {
+    this.setState({
+      breakTime: 5,
+      sessionTime: 25,
+    });
+  }
+
   render() {
     return (
       <div id="content">
@@ -59,6 +67,7 @@ class Pomodoro extends React.Component {
             identity="break-label"
             increment="break-increment"
             decrement="break-decrement"
+            length="break-length"
             increaseTime={this.breakTimeIncrease}
             decreaseTime={this.breakTimeDecrease}
           />
@@ -68,11 +77,12 @@ class Pomodoro extends React.Component {
             identity="session-label"
             increment="session-increment"
             decrement="session-decrement"
+            length="session-length"
             increaseTime={this.sessionTimeIncrease}
             decreaseTime={this.sessionTimeDecrease}
           />
         </div>
-        <DisplayPanel title="Title" time="00:00" />
+        <DisplayPanel title="Session" time="00:00" reset={this.handleReset} />
         <Footer />
       </div>
     );

--- a/src/pomodoro/index.js
+++ b/src/pomodoro/index.js
@@ -4,6 +4,50 @@ import DisplayPanel from './DisplayPanel';
 import Footer from './Footer';
 
 class Pomodoro extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      breakTime: 5,
+      sessionTime: 25,
+    };
+    this.breakTimeIncrease = this.breakTimeIncrease.bind(this);
+    this.breakTimeDecrease = this.breakTimeDecrease.bind(this);
+    this.sessionTimeIncrease = this.sessionTimeIncrease.bind(this);
+    this.sessionTimeDecrease = this.sessionTimeDecrease.bind(this);
+  }
+
+  breakTimeIncrease() {
+    let breakTimer = this.state.breakTime;
+
+    this.setState({
+      breakTime: breakTimer < 60 ? breakTimer + 1 : breakTimer,
+    });
+  }
+
+  breakTimeDecrease() {
+    let breakTimer = this.state.breakTime;
+
+    this.setState({
+      breakTime: breakTimer > 1 ? breakTimer - 1 : breakTimer,
+    });
+  }
+
+  sessionTimeIncrease() {
+    let sessionTimer = this.state.sessionTime;
+
+    this.setState({
+      sessionTime: sessionTimer < 60 ? sessionTimer + 1 : sessionTimer,
+    });
+  }
+
+  sessionTimeDecrease() {
+    let sessionTimer = this.state.sessionTime;
+
+    this.setState({
+      sessionTime: sessionTimer > 1 ? sessionTimer - 1 : sessionTimer,
+    });
+  }
+
   render() {
     return (
       <div id="content">
@@ -11,17 +55,21 @@ class Pomodoro extends React.Component {
         <div id="control_panel">
           <ControlElement
             title="Break"
-            time="00"
+            time={this.state.breakTime}
             identity="break-label"
             increment="break-increment"
             decrement="break-decrement"
+            increaseTime={this.breakTimeIncrease}
+            decreaseTime={this.breakTimeDecrease}
           />
           <ControlElement
             title="Session"
-            time="00"
+            time={this.state.sessionTime}
             identity="session-label"
             increment="session-increment"
             decrement="session-decrement"
+            increaseTime={this.sessionTimeIncrease}
+            decreaseTime={this.sessionTimeDecrease}
           />
         </div>
         <DisplayPanel title="Title" time="00:00" />

--- a/src/pomodoro/index.js
+++ b/src/pomodoro/index.js
@@ -10,11 +10,13 @@ class Pomodoro extends React.Component {
     this.state = {
       breakTime: 5,
       sessionTime: 25,
+      timerRunning: false,
     };
     this.breakTimeIncrease = this.breakTimeIncrease.bind(this);
     this.breakTimeDecrease = this.breakTimeDecrease.bind(this);
     this.sessionTimeIncrease = this.sessionTimeIncrease.bind(this);
     this.sessionTimeDecrease = this.sessionTimeDecrease.bind(this);
+    this.timerPlayAndPause = this.timerPlayAndPause.bind(this);
     this.handleReset = this.handleReset.bind(this);
   }
 
@@ -50,6 +52,12 @@ class Pomodoro extends React.Component {
     });
   }
 
+  timerPlayAndPause() {
+    this.setState({
+      timerRunning: !this.state.timerRunning,
+    });
+  }
+
   handleReset() {
     this.setState({
       breakTime: 5,
@@ -67,7 +75,7 @@ class Pomodoro extends React.Component {
   render() {
     return (
       <div id="content">
-        <h1 id="title">25 + 5 clock</h1>
+        <h1 id="title">Pomodoro Clock</h1>
         <div id="control_panel">
           <ControlElement
             title="Break"
@@ -93,8 +101,12 @@ class Pomodoro extends React.Component {
         <DisplayPanel
           title="Session"
           time={this.timerDisplay()}
+          timerControl={this.timerPlayAndPause}
           reset={this.handleReset}
         />
+        <p style={{ marginTop: 50 }}>
+          timer running: {`${this.state.timerRunning}`}
+        </p>
         <Footer />
       </div>
     );

--- a/src/pomodoro/index.js
+++ b/src/pomodoro/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import ControlElement from './ControlElement';
 import DisplayPanel from './DisplayPanel';
 import Footer from './Footer';
@@ -56,6 +57,13 @@ class Pomodoro extends React.Component {
     });
   }
 
+  timerDisplay() {
+    let minutes = `${this.state.sessionTime}`;
+
+    const timerValue = moment(minutes, 'mm').format('mm:ss');
+    return timerValue;
+  }
+
   render() {
     return (
       <div id="content">
@@ -82,7 +90,11 @@ class Pomodoro extends React.Component {
             decreaseTime={this.sessionTimeDecrease}
           />
         </div>
-        <DisplayPanel title="Session" time="00:00" reset={this.handleReset} />
+        <DisplayPanel
+          title="Session"
+          time={this.timerDisplay()}
+          reset={this.handleReset}
+        />
         <Footer />
       </div>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -7230,6 +7230,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
> User Story # 5

I can see an element with a corresponding id="break-length", which by default (on load) displays a value of 5.

> User Story # 6

I can see an element with a corresponding id="session-length", which by default displays a value of 25.

> User Story # 7

I can see an element with a corresponding id="timer-label", that contains a string indicating a session is initialized (e.g. "Session").

> User Story # 9

I can see a clickable element with a corresponding id="start_stop".

> User Story # 10

I can see a clickable element with a corresponding id="reset".

> User Story # 12

When I click the element with the id of break-decrement, the value within id="break-length" decrements by a value of 1, and I can see the updated value.

> User Story # 13

When I click the element with the id of break-increment, the value within id="break-length" increments by a value of 1, and I can see the updated value.

> User Story # 14

When I click the element with the id of session-decrement, the value within id="session-length" decrements by a value of 1, and I can see the updated value.

> User Story # 15

When I click the element with the id of session-increment, the value within id="session-length" increments by a value of 1, and I can see the updated value.

> User Story # 16

I should not be able to set a session or break length to <= 0.

> User Story # 17

I should not be able to set a session or break length to > 60.

> User Story # 18

When I first click the element with id="start_stop", the timer should begin running from the value currently displayed in id="session-length", even if the value has been incremented or decremented from the original value of 25.
