### PR TITLE
Fulfilled user stories 22 to 25

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ I can see a clickable element with a corresponding id="start_stop".
 
 I can see a clickable element with a corresponding id="reset".
 
-> #11
+> User Story # 11
+
+When I click the element with the id of reset, any running timer should be stopped, the value within id="break-length" should return to 5, the value within id="session-length" should return to 25, and the element with id="time-left" should reset to its default state.
 
 > User Story # 12
 
@@ -74,7 +76,9 @@ When I first click the element with id="start_stop", the timer should begin runn
 
 If the timer is running, the element with the id of time-left should display the remaining time in mm:ss format (decrementing by a value of 1 and updating the display every 1000ms).
 
-> #20
+> User Story # 20
+
+If the timer is running and I click the element with id="start_stop", the countdown should pause.
 
 > User Story # 21
 

--- a/README.md
+++ b/README.md
@@ -83,3 +83,19 @@ If the timer is running and I click the element with id="start_stop", the countd
 > User Story # 21
 
 If the timer is paused and I click the element with id="start_stop", the countdown should resume running from the point at which it was paused.
+
+> User Story # 22
+
+When a session countdown reaches zero (NOTE: timer MUST reach 00:00), and a new countdown begins, the element with the id of timer-label should display a string indicating a break has begun.
+
+> User Story # 23
+
+When a session countdown reaches zero (NOTE: timer MUST reach 00:00), a new break countdown should begin, counting down from the value currently displayed in the id="break-length" element.
+
+> User Story # 24
+
+When a break countdown reaches zero (NOTE: timer MUST reach 00:00), and a new countdown begins, the element with the id of timer-label should display a string indicating a session has begun.
+
+> User Story # 25
+
+When a break countdown reaches zero (NOTE: timer MUST reach 00:00), a new session countdown should begin, counting down from the value currently displayed in the id="session-length" element.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ I can see an element with a corresponding id="session-length", which by default 
 
 I can see an element with a corresponding id="timer-label", that contains a string indicating a session is initialized (e.g. "Session").
 
-> #8
+> User Story # 8
+
+I can see an element with corresponding id="time-left". NOTE: Paused or running, the value in this field should always be displayed in mm:ss format (i.e. 25:00).
 
 > User Story # 9
 

--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ I should not be able to set a session or break length to > 60.
 > User Story # 18
 
 When I first click the element with id="start_stop", the timer should begin running from the value currently displayed in id="session-length", even if the value has been incremented or decremented from the original value of 25.
+
+> User Story # 19
+
+If the timer is running, the element with the id of time-left should display the remaining time in mm:ss format (decrementing by a value of 1 and updating the display every 1000ms).
+
+> #20
+
+> User Story # 21
+
+If the timer is paused and I click the element with id="start_stop", the countdown should resume running from the point at which it was paused.

--- a/src/pomodoro/index.js
+++ b/src/pomodoro/index.js
@@ -17,8 +17,11 @@ class Pomodoro extends React.Component {
     this.breakTimeDecrease = this.breakTimeDecrease.bind(this);
     this.sessionTimeIncrease = this.sessionTimeIncrease.bind(this);
     this.sessionTimeDecrease = this.sessionTimeDecrease.bind(this);
-    this.timerPlayAndPause = this.timerPlayAndPause.bind(this);
     this.handleReset = this.handleReset.bind(this);
+    this.countdownAction = this.countdownAction.bind(this);
+    this.beginCountdown = this.beginCountdown.bind(this);
+    this.stopCountdown = this.stopCountdown.bind(this);
+    this.timerPlayAndPause = this.timerPlayAndPause.bind(this);
   }
 
   breakTimeIncrease() {
@@ -60,14 +63,6 @@ class Pomodoro extends React.Component {
     });
   }
 
-  timerPlayAndPause() {
-    this.setState({
-      timerRunning: !this.state.timerRunning,
-    });
-  }
-
-  beginCountdown() {}
-
   handleReset() {
     this.setState({
       breakTime: 5,
@@ -76,28 +71,34 @@ class Pomodoro extends React.Component {
     });
   }
 
+  countdownAction() {
+    // console.log(
+    //   'hr: ' +
+    //     this.state.timerFace.hour().toString() +
+    //     ' | mins: ' +
+    //     this.state.timerFace.minutes().toString() +
+    //     ' | secs: ' +
+    //     this.state.timerFace.seconds().toString(),
+    // );
+
+    this.setState({ timerFace: this.state.timerFace.subtract(1, 'seconds') });
+  }
+
+  beginCountdown() {
+    this.intervalId = setInterval(this.countdownAction, 1000);
+    this.setState({ timerRunning: true });
+  }
+
+  stopCountdown() {
+    clearInterval(this.intervalId);
+    this.setState({ timerRunning: false });
+  }
+
+  timerPlayAndPause() {
+    !this.state.timerRunning ? this.beginCountdown() : this.stopCountdown();
+  }
+
   render() {
-    // if (this.state.timerRunning) {
-    //   while (this.state.timerFace.isAfter(new Date(2000, 1, 0, 0, 0, 0))) {
-    //     setTimeout(() => {
-    //       console.log(
-    //         'hr: ' +
-    //           this.state.timerFace.hour().toString() +
-    //           ' | mins: ' +
-    //           this.state.timerFace.minutes().toString() +
-    //           ' | secs: ' +
-    //           this.state.timerFace.seconds().toString(),
-    //       );
-    //       this.state.timerFace.subtract(1, 'seconds');
-    //     }, 1000);
-    //   }
-    // }
-
-    const timeRelay =
-      this.state.timerFace.hour() < 1
-        ? this.state.timerFace.format('mm:ss')
-        : '60:00';
-
     return (
       <div id="content">
         <h1 id="title">Pomodoro Clock</h1>
@@ -125,7 +126,11 @@ class Pomodoro extends React.Component {
         </div>
         <DisplayPanel
           title="Session"
-          time={timeRelay}
+          time={
+            this.state.timerFace.hour() < 1
+              ? this.state.timerFace.format('mm:ss')
+              : '60:00'
+          }
           timerControl={this.timerPlayAndPause}
           reset={this.handleReset}
         />

--- a/src/pomodoro/index.js
+++ b/src/pomodoro/index.js
@@ -7,6 +7,7 @@ import Footer from './Footer';
 class Pomodoro extends React.Component {
   constructor(props) {
     super(props);
+
     this.state = {
       breakTime: 5,
       sessionTime: 25,
@@ -14,6 +15,7 @@ class Pomodoro extends React.Component {
       timerFace: moment(new Date(2000, 1, 2, 0, 25, 0)),
       title: 'Session',
     };
+
     this.breakTimeIncrease = this.breakTimeIncrease.bind(this);
     this.breakTimeDecrease = this.breakTimeDecrease.bind(this);
     this.sessionTimeIncrease = this.sessionTimeIncrease.bind(this);
@@ -22,6 +24,9 @@ class Pomodoro extends React.Component {
     this.countdownAction = this.countdownAction.bind(this);
     this.beginCountdown = this.beginCountdown.bind(this);
     this.stopCountdown = this.stopCountdown.bind(this);
+    this.breakAction = this.breakAction.bind(this);
+    this.beginBreak = this.beginBreak.bind(this);
+    this.stopBreak = this.stopBreak.bind(this);
     this.timerPlayAndPause = this.timerPlayAndPause.bind(this);
   }
 
@@ -82,7 +87,8 @@ class Pomodoro extends React.Component {
       timerRunning: false,
     });
 
-    clearInterval(this.intervalId);
+    clearInterval(this.intervalCountdownId);
+    clearInterval(this.intervalBreakId);
   }
 
   countdownAction() {
@@ -92,16 +98,46 @@ class Pomodoro extends React.Component {
 
     if (timerDisplay.innerHTML === '00:00') {
       this.stopCountdown();
+      this.setState({
+        title: 'Break',
+        timerFace: moment(new Date(2000, 1, 2, 0, this.state.breakTime, 0)),
+      });
+      this.beginBreak();
     }
   }
 
   beginCountdown() {
-    this.intervalId = setInterval(this.countdownAction, 1000);
+    this.intervalCountdownId = setInterval(this.countdownAction, 1000);
     this.setState({ timerRunning: true });
   }
 
   stopCountdown() {
-    clearInterval(this.intervalId);
+    clearInterval(this.intervalCountdownId);
+    this.setState({ timerRunning: false });
+  }
+
+  breakAction() {
+    this.setState({ timerFace: this.state.timerFace.subtract(1, 'seconds') });
+
+    const timerDisplay = document.querySelector('.timer-display');
+
+    if (timerDisplay.innerHTML === '00:00') {
+      this.stopBreak();
+      this.setState({
+        title: 'Session',
+        timerFace: moment(new Date(2000, 1, 2, 0, this.state.sessionTime, 0)),
+      });
+      this.beginCountdown();
+    }
+  }
+
+  beginBreak() {
+    this.intervalBreakId = setInterval(this.breakAction, 1000);
+    this.setState({ timerRunning: true });
+  }
+
+  stopBreak() {
+    clearInterval(this.intervalBreakId);
     this.setState({ timerRunning: false });
   }
 

--- a/src/pomodoro/index.js
+++ b/src/pomodoro/index.js
@@ -11,6 +11,7 @@ class Pomodoro extends React.Component {
       breakTime: 5,
       sessionTime: 25,
       timerRunning: false,
+      timerFace: moment(new Date(2000, 1, 0, 0, 25, 0)),
     };
     this.breakTimeIncrease = this.breakTimeIncrease.bind(this);
     this.breakTimeDecrease = this.breakTimeDecrease.bind(this);
@@ -38,17 +39,24 @@ class Pomodoro extends React.Component {
 
   sessionTimeIncrease() {
     let sessionTimer = this.state.sessionTime;
+    let sessionCondition = sessionTimer < 60 ? sessionTimer + 1 : sessionTimer;
+    let timeCondition = sessionCondition > 59 ? [0, 1] : [sessionCondition, 0];
 
     this.setState({
-      sessionTime: sessionTimer < 60 ? sessionTimer + 1 : sessionTimer,
+      sessionTime: sessionCondition,
+      timerFace: moment(
+        new Date(2000, 1, 0, timeCondition[1], timeCondition[0], 0),
+      ),
     });
   }
 
   sessionTimeDecrease() {
     let sessionTimer = this.state.sessionTime;
+    let sessionCondition = sessionTimer > 1 ? sessionTimer - 1 : sessionTimer;
 
     this.setState({
-      sessionTime: sessionTimer > 1 ? sessionTimer - 1 : sessionTimer,
+      sessionTime: sessionCondition,
+      timerFace: moment(new Date(2000, 1, 0, 0, sessionCondition, 0)),
     });
   }
 
@@ -58,21 +66,38 @@ class Pomodoro extends React.Component {
     });
   }
 
+  beginCountdown() {}
+
   handleReset() {
     this.setState({
       breakTime: 5,
       sessionTime: 25,
+      timerFace: moment(new Date(2000, 1, 0, 0, 25, 0)),
     });
   }
 
-  timerDisplay() {
-    let minutes = `${this.state.sessionTime}`;
-
-    const timerValue = moment(minutes, 'mm').format('mm:ss');
-    return timerValue;
-  }
-
   render() {
+    // if (this.state.timerRunning) {
+    //   while (this.state.timerFace.isAfter(new Date(2000, 1, 0, 0, 0, 0))) {
+    //     setTimeout(() => {
+    //       console.log(
+    //         'hr: ' +
+    //           this.state.timerFace.hour().toString() +
+    //           ' | mins: ' +
+    //           this.state.timerFace.minutes().toString() +
+    //           ' | secs: ' +
+    //           this.state.timerFace.seconds().toString(),
+    //       );
+    //       this.state.timerFace.subtract(1, 'seconds');
+    //     }, 1000);
+    //   }
+    // }
+
+    const timeRelay =
+      this.state.timerFace.hour() < 1
+        ? this.state.timerFace.format('mm:ss')
+        : '60:00';
+
     return (
       <div id="content">
         <h1 id="title">Pomodoro Clock</h1>
@@ -100,7 +125,7 @@ class Pomodoro extends React.Component {
         </div>
         <DisplayPanel
           title="Session"
-          time={this.timerDisplay()}
+          time={timeRelay}
           timerControl={this.timerPlayAndPause}
           reset={this.handleReset}
         />

--- a/src/pomodoro/index.js
+++ b/src/pomodoro/index.js
@@ -11,7 +11,7 @@ class Pomodoro extends React.Component {
       breakTime: 5,
       sessionTime: 25,
       timerRunning: false,
-      timerFace: moment(new Date(2000, 1, 0, 0, 25, 0)),
+      timerFace: moment(new Date(2000, 1, 2, 0, 25, 0)),
       title: 'Session',
     };
     this.breakTimeIncrease = this.breakTimeIncrease.bind(this);
@@ -68,9 +68,8 @@ class Pomodoro extends React.Component {
 
     this.setState({
       sessionTime: !this.state.timerRunning ? sessionCondition : sessionTimer,
-      // sessionTime: sessionCondition,
       timerFace: !this.state.timerRunning
-        ? moment(new Date(2000, 1, 0, 0, sessionCondition, 0))
+        ? moment(new Date(2000, 1, 2, 0, sessionCondition, 0))
         : this.state.timerFace,
     });
   }
@@ -79,7 +78,7 @@ class Pomodoro extends React.Component {
     this.setState({
       breakTime: 5,
       sessionTime: 25,
-      timerFace: moment(new Date(2000, 1, 0, 0, 25, 0)),
+      timerFace: moment(new Date(2000, 1, 2, 0, 25, 0)),
       timerRunning: false,
     });
 
@@ -88,6 +87,12 @@ class Pomodoro extends React.Component {
 
   countdownAction() {
     this.setState({ timerFace: this.state.timerFace.subtract(1, 'seconds') });
+
+    const timerDisplay = document.querySelector('.timer-display');
+
+    if (timerDisplay.innerHTML === '00:00') {
+      this.stopCountdown();
+    }
   }
 
   beginCountdown() {

--- a/src/pomodoro/index.js
+++ b/src/pomodoro/index.js
@@ -68,7 +68,10 @@ class Pomodoro extends React.Component {
       breakTime: 5,
       sessionTime: 25,
       timerFace: moment(new Date(2000, 1, 0, 0, 25, 0)),
+      timerRunning: false,
     });
+
+    clearInterval(this.intervalId);
   }
 
   countdownAction() {

--- a/src/pomodoro/index.js
+++ b/src/pomodoro/index.js
@@ -85,6 +85,7 @@ class Pomodoro extends React.Component {
       sessionTime: 25,
       timerFace: moment(new Date(2000, 1, 2, 0, 25, 0)),
       timerRunning: false,
+      title: 'Session',
     });
 
     clearInterval(this.intervalCountdownId);

--- a/src/pomodoro/index.js
+++ b/src/pomodoro/index.js
@@ -97,7 +97,7 @@ class Pomodoro extends React.Component {
 
     const timerDisplay = document.querySelector('.timer-display');
 
-    if (timerDisplay.innerHTML === '00:00') {
+    if (timerDisplay.innerHTML === '60:00') {
       this.stopCountdown();
       this.setState({
         title: 'Break',
@@ -122,7 +122,7 @@ class Pomodoro extends React.Component {
 
     const timerDisplay = document.querySelector('.timer-display');
 
-    if (timerDisplay.innerHTML === '00:00') {
+    if (timerDisplay.innerHTML === '60:00') {
       this.stopBreak();
       this.setState({
         title: 'Session',

--- a/src/pomodoro/index.js
+++ b/src/pomodoro/index.js
@@ -12,6 +12,7 @@ class Pomodoro extends React.Component {
       sessionTime: 25,
       timerRunning: false,
       timerFace: moment(new Date(2000, 1, 0, 0, 25, 0)),
+      title: 'Session',
     };
     this.breakTimeIncrease = this.breakTimeIncrease.bind(this);
     this.breakTimeDecrease = this.breakTimeDecrease.bind(this);
@@ -28,7 +29,11 @@ class Pomodoro extends React.Component {
     let breakTimer = this.state.breakTime;
 
     this.setState({
-      breakTime: breakTimer < 60 ? breakTimer + 1 : breakTimer,
+      breakTime: !this.state.timerRunning
+        ? breakTimer < 60
+          ? breakTimer + 1
+          : breakTimer
+        : breakTimer,
     });
   }
 
@@ -36,7 +41,11 @@ class Pomodoro extends React.Component {
     let breakTimer = this.state.breakTime;
 
     this.setState({
-      breakTime: breakTimer > 1 ? breakTimer - 1 : breakTimer,
+      breakTime: !this.state.timerRunning
+        ? breakTimer > 1
+          ? breakTimer - 1
+          : breakTimer
+        : breakTimer,
     });
   }
 
@@ -46,10 +55,10 @@ class Pomodoro extends React.Component {
     let timeCondition = sessionCondition > 59 ? [0, 1] : [sessionCondition, 0];
 
     this.setState({
-      sessionTime: sessionCondition,
-      timerFace: moment(
-        new Date(2000, 1, 0, timeCondition[1], timeCondition[0], 0),
-      ),
+      sessionTime: !this.state.timerRunning ? sessionCondition : sessionTimer,
+      timerFace: !this.state.timerRunning
+        ? moment(new Date(2000, 1, 0, timeCondition[1], timeCondition[0], 0))
+        : this.state.timerFace,
     });
   }
 
@@ -58,8 +67,11 @@ class Pomodoro extends React.Component {
     let sessionCondition = sessionTimer > 1 ? sessionTimer - 1 : sessionTimer;
 
     this.setState({
-      sessionTime: sessionCondition,
-      timerFace: moment(new Date(2000, 1, 0, 0, sessionCondition, 0)),
+      sessionTime: !this.state.timerRunning ? sessionCondition : sessionTimer,
+      // sessionTime: sessionCondition,
+      timerFace: !this.state.timerRunning
+        ? moment(new Date(2000, 1, 0, 0, sessionCondition, 0))
+        : this.state.timerFace,
     });
   }
 
@@ -75,15 +87,6 @@ class Pomodoro extends React.Component {
   }
 
   countdownAction() {
-    // console.log(
-    //   'hr: ' +
-    //     this.state.timerFace.hour().toString() +
-    //     ' | mins: ' +
-    //     this.state.timerFace.minutes().toString() +
-    //     ' | secs: ' +
-    //     this.state.timerFace.seconds().toString(),
-    // );
-
     this.setState({ timerFace: this.state.timerFace.subtract(1, 'seconds') });
   }
 
@@ -128,7 +131,7 @@ class Pomodoro extends React.Component {
           />
         </div>
         <DisplayPanel
-          title="Session"
+          title={this.state.title}
           time={
             this.state.timerFace.hour() < 1
               ? this.state.timerFace.format('mm:ss')


### PR DESCRIPTION
> User Story # 22

When a session countdown reaches zero (NOTE: timer MUST reach 00:00), and a new countdown begins, the element with the id of timer-label should display a string indicating a break has begun.

> User Story # 23

When a session countdown reaches zero (NOTE: timer MUST reach 00:00), a new break countdown should begin, counting down from the value currently displayed in the id="break-length" element.

> User Story # 24

When a break countdown reaches zero (NOTE: timer MUST reach 00:00), and a new countdown begins, the element with the id of timer-label should display a string indicating a session has begun.

> User Story # 25

When a break countdown reaches zero (NOTE: timer MUST reach 00:00), a new session countdown should begin, counting down from the value currently displayed in the id="session-length" element.
